### PR TITLE
Add support for scheme and verify in config schema

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,6 +1,6 @@
 ---
   host:
-    description: "Consul server IP/name - default 127.0.0.1"
+    description: "Consul server IP/name.  Default 127.0.0.1"
     type: "string"
     secret: false
     required: true
@@ -16,3 +16,13 @@
     type: "string"
     secret: true
     required: true
+  scheme:
+    description: "Consul scheme to use. Default http"
+    type: "string"
+    required: false
+    default: "http"
+  verify:
+    description: "Verify the SSL certificate for HTTPS requests. Default false"
+    type: "boolean"
+    required: false
+    default: false


### PR DESCRIPTION
Added two extra parameters to consul pack's configuration schema to fix error `KeyError: 'scheme'` when running actions.