### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.5.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 ## 0.4.0
 
  - Added consul.health_service action to query a services status and group the result by hostname

--- a/actions/create_token.yaml
+++ b/actions/create_token.yaml
@@ -1,6 +1,6 @@
 name: create_token
 pack: consul
-runner_type: run-python
+runner_type: python-script
 description: "Create an acl token"
 enabled: true
 entry_point: "create_token.py"

--- a/actions/delete.yaml
+++ b/actions/delete.yaml
@@ -1,6 +1,6 @@
 name: delete
 pack: consul
-runner_type: run-python
+runner_type: python-script
 description: "Delete value from Consul server"
 enabled: true
 entry_point: "delete.py"

--- a/actions/deregister_service.yaml
+++ b/actions/deregister_service.yaml
@@ -1,5 +1,5 @@
 name: deregister_service
-runner_type: run-python
+runner_type: python-script
 description: "De-Register an external service in Consul"
 enabled: true
 entry_point: "deregister_service.py"

--- a/actions/destroy_token.yaml
+++ b/actions/destroy_token.yaml
@@ -1,6 +1,6 @@
 name: destroy_token
 pack: consul
-runner_type: run-python
+runner_type: python-script
 description: "Destroy an acl token"
 enabled: true
 entry_point: "destroy_token.py"

--- a/actions/get.yaml
+++ b/actions/get.yaml
@@ -1,5 +1,5 @@
 name: get
-runner_type: run-python
+runner_type: python-script
 description: "Get value from Consul server"
 enabled: true
 entry_point: "get.py"

--- a/actions/health_check.yaml
+++ b/actions/health_check.yaml
@@ -1,5 +1,5 @@
 name: health_check
-runner_type: run-python
+runner_type: python-script
 description: "Query health status of a check in consul"
 enabled: true
 entry_point: "health_check.py"

--- a/actions/health_service.yaml
+++ b/actions/health_service.yaml
@@ -1,5 +1,5 @@
 name: health_service
-runner_type: run-python
+runner_type: python-script
 description: "Query health status of a service in consul"
 enabled: true
 entry_point: "health_service.py"

--- a/actions/list.yaml
+++ b/actions/list.yaml
@@ -1,5 +1,5 @@
 name: list
-runner_type: run-python
+runner_type: python-script
 description: "List values from Consul server"
 enabled: true
 entry_point: "get.py"

--- a/actions/list_datacenters.yaml
+++ b/actions/list_datacenters.yaml
@@ -1,5 +1,5 @@
 name: list_datacenters
-runner_type: run-python
+runner_type: python-script
 description: "Real-time query of all known datacenters in Consul"
 enabled: true
 entry_point: "list_datacenters.py"

--- a/actions/list_nodes.yaml
+++ b/actions/list_nodes.yaml
@@ -1,5 +1,5 @@
 name: list_nodes
-runner_type: run-python
+runner_type: python-script
 description: "Real-time query of all known nodes in Consul"
 enabled: true
 entry_point: "list_nodes.py"

--- a/actions/list_services.yaml
+++ b/actions/list_services.yaml
@@ -1,5 +1,5 @@
 name: list_services
-runner_type: run-python
+runner_type: python-script
 description: "Real-time query of all known services in Consul"
 enabled: true
 entry_point: "list_services.py"

--- a/actions/list_tokens.yaml
+++ b/actions/list_tokens.yaml
@@ -1,6 +1,6 @@
 name: list_tokens
 pack: consul
-runner_type: run-python
+runner_type: python-script
 description: "List all acl tokens"
 enabled: true
 entry_point: "list_tokens.py"

--- a/actions/parse_nodes.yaml
+++ b/actions/parse_nodes.yaml
@@ -1,5 +1,5 @@
 name: parse_nodes
-runner_type: run-python
+runner_type: python-script
 description: "Helper function to extract hosts from a consul response to be used with StackStorm workflows"
 enabled: true
 entry_point: "parse_nodes"

--- a/actions/put.yaml
+++ b/actions/put.yaml
@@ -1,5 +1,5 @@
 name: put
-runner_type: run-python
+runner_type: python-script
 description: "Put value in Consul server"
 enabled: true
 entry_point: "put.py"

--- a/actions/query_node.yaml
+++ b/actions/query_node.yaml
@@ -1,5 +1,5 @@
 name: query_node
-runner_type: run-python
+runner_type: python-script
 description: "Query details about a node in consul"
 enabled: true
 entry_point: "query_node.py"

--- a/actions/query_service.yaml
+++ b/actions/query_service.yaml
@@ -1,5 +1,5 @@
 name: query_service
-runner_type: run-python
+runner_type: python-script
 description: "Query details about a service in consul"
 enabled: true
 entry_point: "query_service.py"

--- a/actions/register_service.yaml
+++ b/actions/register_service.yaml
@@ -1,5 +1,5 @@
 name: register_service
-runner_type: run-python
+runner_type: python-script
 description: "Register an external service in Consul"
 enabled: true
 entry_point: "register_service.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,6 +3,6 @@
 ref: consul
 name: consul
 description: consul
-version: 0.4.0
+version: 0.5.0
 author: jfryman
 email: james@fryman.io


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.