### PR TITLE
Linting fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.6.1] 27 Nov 2017
+
+- Linting fixes
+
 ## [0.6.0] 16 Nov 2017
 
 ### Added the following API calls. (See https://python-consul.readthedocs.io for documentation)

--- a/actions/acl_list.py
+++ b/actions/acl_list.py
@@ -1,6 +1,6 @@
-from lib import action
-
 import json
+
+from lib import action
 
 
 class ConsulAclListAction(action.ConsulBaseAction):

--- a/actions/agent_service_deregister.py
+++ b/actions/agent_service_deregister.py
@@ -3,4 +3,4 @@ from lib import action
 
 class ConsulServiceDeregisterAction(action.ConsulBaseAction):
     def run(self, service_id):
-        return (True, self.consul.service.deregister(service_id=service_id))
+        return (True, self.consul.agent.service.deregister(service_id=service_id))

--- a/actions/agent_service_deregister.yaml
+++ b/actions/agent_service_deregister.yaml
@@ -2,7 +2,7 @@ name: service_deregister
 runner_type: python-script
 description: "Remove a service from the local agent."
 enabled: true
-entry_point: "service_deregister.py"
+entry_point: "agent_service_deregister.py"
 parameters:
     service_id:
         type: string

--- a/actions/agent_service_maintenance.py
+++ b/actions/agent_service_maintenance.py
@@ -3,7 +3,7 @@ from lib import action
 
 class ConsulServiceMaintenanceAction(action.ConsulBaseAction):
     def run(self, service_id, enable, reason=None):
-        return (True, self.consul.service.maintenance(
+        return (True, self.consul.agent.service.maintenance(
             service_id=service_id,
             enable=enable,
             reason=reason

--- a/actions/agent_service_maintenance.yaml
+++ b/actions/agent_service_maintenance.yaml
@@ -2,7 +2,7 @@ name: service_maintenance
 runner_type: python-script
 description: "Put a given service into _maintenance mode_."
 enabled: true
-entry_point: "service_maintenance.py"
+entry_point: "agent_service_maintenance.py"
 parameters:
     service_id:
         type: string

--- a/actions/agent_service_register.py
+++ b/actions/agent_service_register.py
@@ -11,7 +11,7 @@ class ConsulServiceRegisterAction(action.ConsulBaseAction):
             check=None,
             token=None,
             enable_tag_override=False):
-        return (True, self.consul.service.register(
+        return (True, self.consul.agent.service.register(
             name=name,
             service_id=service_id,
             address=address,

--- a/actions/agent_service_register.yaml
+++ b/actions/agent_service_register.yaml
@@ -2,7 +2,7 @@ name: service_register
 runner_type: python-script
 description: "Add a new service to the local agent."
 enabled: true
-entry_point: "service_register.py"
+entry_point: "agent_service_register.py"
 parameters:
     name:
         type: string

--- a/actions/catalog_node.py
+++ b/actions/catalog_node.py
@@ -2,20 +2,18 @@ from lib import action
 
 
 class ConsulCatalogNodeAction(action.ConsulBaseAction):
-    def run(
-        self,
-        node,
-        index=None,
-        wait=None,
-        consistency=None,
-        dc=None,
-        token=None
-    ):
-        return (True, self.consul.catalog.node(
+    def run(self,
             node,
-            index=index,
-            wait=wait,
-            consistency=consistency,
-            dc=dc,
-            token=token
-            ))
+            index=None,
+            wait=None,
+            consistency=None,
+            dc=None,
+            token=None):
+
+        return (True,
+                self.consul.catalog.node(node,
+                                         index=index,
+                                         wait=wait,
+                                         consistency=consistency,
+                                         dc=dc,
+                                         token=token))

--- a/actions/catalog_nodes.py
+++ b/actions/catalog_nodes.py
@@ -2,15 +2,13 @@ from lib import action
 
 
 class ConsulCatalogNodesAction(action.ConsulBaseAction):
-    def run(
-        self,
-        index=None,
-        wait=None,
-        consistency=None,
-        dc=None,
-        near=None,
-        token=None
-    ):
+    def run(self,
+            index=None,
+            wait=None,
+            consistency=None,
+            dc=None,
+            near=None,
+            token=None):
 
         return (True, self.consul.catalog.nodes(
             index=index,

--- a/actions/catalog_service.py
+++ b/actions/catalog_service.py
@@ -2,17 +2,15 @@ from lib import action
 
 
 class ConsulCatalogServiceAction(action.ConsulBaseAction):
-    def run(
-        self,
-        service,
-        index=None,
-        wait=None,
-        tag=None,
-        consistency=None,
-        dc=None,
-        near=None,
-        token=None
-    ):
+    def run(self,
+            service,
+            index=None,
+            wait=None,
+            tag=None,
+            consistency=None,
+            dc=None,
+            near=None,
+            token=None):
 
         return (True, self.consul.catalog.service(
             service=service,

--- a/actions/catalog_services.py
+++ b/actions/catalog_services.py
@@ -2,14 +2,12 @@ from lib import action
 
 
 class ConsulCatalogServicesAction(action.ConsulBaseAction):
-    def run(
-        self,
-        index=None,
-        wait=None,
-        consistency=None,
-        dc=None,
-        token=None
-    ):
+    def run(self,
+            index=None,
+            wait=None,
+            consistency=None,
+            dc=None,
+            token=None):
 
         return (True, self.consul.catalog.services(
             index=index,

--- a/actions/event_fire.py
+++ b/actions/event_fire.py
@@ -2,13 +2,12 @@ from lib import action
 
 
 class ConsulEventFireAction(action.ConsulBaseAction):
-    def run(
-        self,
-        name,
-        body="",
-        node=None,
-        service=None,
-        tag=None):
+    def run(self,
+            name,
+            body="",
+            node=None,
+            service=None,
+            tag=None):
 
         if len(body) > 100:
             self.logger.warn("Event body being fired exceeds the recommended 100 byte limit!")

--- a/actions/event_list.py
+++ b/actions/event_list.py
@@ -2,12 +2,10 @@ from lib import action
 
 
 class ConsulEventListAction(action.ConsulBaseAction):
-    def run(
-        self,
-        name=None,
-        index=None,
-        wait=None
-    ):
+    def run(self,
+            name=None,
+            index=None,
+            wait=None):
 
         if name == "":
             name = None

--- a/actions/kv_get.py
+++ b/actions/kv_get.py
@@ -1,5 +1,4 @@
 from lib import action
-import json
 
 
 class ConsulKVGetAction(action.ConsulBaseAction):
@@ -27,7 +26,7 @@ class ConsulKVGetAction(action.ConsulBaseAction):
 
         if from_json and not keys:
             if isinstance(res, dict):
-                    res["Value"] = self.from_json(res["Value"])
+                res["Value"] = self.from_json(res["Value"])
             if isinstance(res, list):
                 for item in res:
                     item["Value"] = self.from_json(item["Value"])

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -38,6 +38,6 @@ class ConsulBaseAction(Action):
         """
         try:
             value = json.loads(value)
-        except ValueError as ignore_exception:
+        except ValueError:
             pass
         return value

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -1,9 +1,9 @@
+import json
 from st2common import log as logging
 from st2common.runners.base_action import Action
 
 # http://python-consul.readthedocs.org/en/latest/#
 import consul
-import json
 
 
 class ConsulBaseAction(Action):

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: consul
 name: consul
 description: consul
-version: 0.6.0
+version: 0.6.1
 author: jfryman
 email: james@fryman.io


### PR DESCRIPTION
Linting cleanups - looks like CircleCI checks did not run on the previous merge.

@nzlosh can you fix the remaining linting errors here?

```
Running pylint on pack: stackstorm-consul
************* Module service_deregister
E:  6,22: Instance of 'Consul' has no 'service' member (no-member)
************* Module service_maintenance
E:  6,22: Instance of 'Consul' has no 'service' member (no-member)
************* Module service_register
E: 14,22: Instance of 'Consul' has no 'service' member (no-member)
make: *** [.pylint] Error 1
```