### PR TITLE
A check needs to be an object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.6.4] 16 Jul 2018
+
+### Changed
+  - Update agent_service_register `check` to be an object.
+  
 ## [0.6.3] 25 Jan 2018
 
 ### Added

--- a/actions/agent_service_register.yaml
+++ b/actions/agent_service_register.yaml
@@ -25,7 +25,7 @@ parameters:
         description: "Tags."
         required: false
     check:
-        type: string
+        type: object
         description: "An optional health *check* can be created for this service."
         required: false
     token:

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: consul
 name: consul
 description: consul
-version: 0.6.3
+version: 0.6.4
 author: jfryman
 email: james@fryman.io


### PR DESCRIPTION
`agent_service_register.yaml`  is expecting a `string` for the `check` - but the base Consul is looking for a dict.