### PR TITLE
ACL and token support.  Bump python-consul module to 1.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,35 @@
 # Change Log
 
+## [0.6.6] 16 Feb 2019
+
+### Added
+  - Pack supports client key/certificate and CA certificate parameters. issue #22
+  - Pack supports consul profiles.  issue #23
+  - New Actions
+    - ACLInfo
+    - ACLUpdate
+    - ACLClone
+
+### Changed
+  - Fixed destory_session method to return the result.
+  - Updated all actions to support ACL Tokens.
+  - Require python-consul v1.1.0
+  - Changed Actions
+    - All actions take a consul_profile parameter.  If no profile is provided the action uses consul_default as defined in the pack configuration.
+    - CatalogDeregister takes check_id and token.
+    - CatalogServices takes node_meta.
+    - CatalogNodes takes node_meta.
+    
 ## [0.6.5] 16 Jul 2018
 
 ### Changed
   - Update agent_service_register `tags` to be an array.
-  
+
 ## [0.6.4] 16 Jul 2018
 
 ### Changed
   - Update agent_service_register `check` to be an object.
-  
+
 ## [0.6.3] 25 Jan 2018
 
 ### Added
@@ -52,6 +72,7 @@
     - SessionList
     - SessionNode
     - SessionRenew
+
 ### Changed
  - Renamed existing action names to be aligned with the consul API.  This helps logically group
    operations by the subsystem they will apply to.

--- a/actions/acl_clone.py
+++ b/actions/acl_clone.py
@@ -1,11 +1,11 @@
 from lib import action
 
 
-class ConsulAclDestroyAction(action.ConsulBaseAction):
+class ConsulAclCloneAction(action.ConsulBaseAction):
     def run(self, acl_id, consul_profile=None, token=None):
         self._create_client(consul_profile)
         # Action parameter "token" defaults to an empty string when no input is provided.
         # Consul-Python tests for None to use the agent's token, so "token" set to None here.
         if token == "":
             token = None
-        return (True, self.consul.acl.destroy(acl_id, token=token))
+        return (True, self.consul.acl.clone(acl_id, token=token))

--- a/actions/acl_clone.yaml
+++ b/actions/acl_clone.yaml
@@ -1,20 +1,19 @@
-name: acl_destroy
+name: acl_clone
 pack: consul
 runner_type: python-script
-description: "Destroys the ACL token 'acl_id'"
+description: "Clones the ACL token 'acl_id'."
 enabled: true
-entry_point: "acl_destroy.py"
+entry_point: "acl_clone.py"
 parameters:
     acl_id:
         type: string
-        description: "Token to destroy"
+        description: "'acl_id' to clone."
         required: true
-        position: 0
     token:
         type: string
-        description: An ACL token to use instead of the agent token.
-        secret: true
+        description: "An ACL token to use instead of the agent token."
         required: false
+        secret: true
         default: ""
     consul_profile:
         type: string

--- a/actions/acl_info.py
+++ b/actions/acl_info.py
@@ -1,11 +1,11 @@
 from lib import action
 
 
-class ConsulAclDestroyAction(action.ConsulBaseAction):
+class ConsulAclInfoAction(action.ConsulBaseAction):
     def run(self, acl_id, consul_profile=None, token=None):
         self._create_client(consul_profile)
         # Action parameter "token" defaults to an empty string when no input is provided.
         # Consul-Python tests for None to use the agent's token, so "token" set to None here.
         if token == "":
             token = None
-        return (True, self.consul.acl.destroy(acl_id, token=token))
+        return (True, self.consul.acl.info(acl_id, token=token))

--- a/actions/acl_info.yaml
+++ b/actions/acl_info.yaml
@@ -1,15 +1,14 @@
-name: acl_destroy
+name: acl_info
 pack: consul
 runner_type: python-script
-description: "Destroys the ACL token 'acl_id'"
+description: "Returns the token information for 'acl_id'."
 enabled: true
-entry_point: "acl_destroy.py"
+entry_point: "acl_info.py"
 parameters:
     acl_id:
         type: string
-        description: "Token to destroy"
+        description: Fetch information for 'acl_id'.
         required: true
-        position: 0
     token:
         type: string
         description: An ACL token to use instead of the agent token.

--- a/actions/acl_list.py
+++ b/actions/acl_list.py
@@ -2,5 +2,10 @@ from lib import action
 
 
 class ConsulAclListAction(action.ConsulBaseAction):
-    def run(self):
-        return (True, self.consul.acl.list())
+    def run(self, consul_profile=None, token=None):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        return (True, self.consul.acl.list(token=token))

--- a/actions/acl_list.yaml
+++ b/actions/acl_list.yaml
@@ -1,6 +1,17 @@
 name: acl_list
 pack: consul
 runner_type: python-script
-description: "List all acl tokens"
+description: "Lists all the active ACL tokens."
 enabled: true
 entry_point: "acl_list.py"
+parameters:
+    token:
+        type: string
+        description: An ACL token to use instead of the agent token.
+        secret: true
+        required: false
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/acl_update.py
+++ b/actions/acl_update.py
@@ -1,7 +1,7 @@
 from lib import action
 
 
-class ConsulAclCreateAction(action.ConsulBaseAction):
+class ConsulAclUpdateAction(action.ConsulBaseAction):
     def run(
         self,
         consul_profile=None,
@@ -21,11 +21,11 @@ class ConsulAclCreateAction(action.ConsulBaseAction):
         rules = rules.encode("ascii", "ignore")
         return (
             True,
-            self.consul.acl.create(
+            self.consul.acl.update(
+                acl_id,
                 name=name,
                 type=acl_type,
                 rules=rules,
-                acl_id=acl_id,
                 token=token
             )
         )

--- a/actions/acl_update.yaml
+++ b/actions/acl_update.yaml
@@ -1,15 +1,15 @@
-name: acl_create
+name: acl_update
 pack: consul
 runner_type: python-script
-description: "Creates a new ACL token."
+description: "Updates the ACL token 'acl_id'."
 enabled: true
-entry_point: "acl_create.py"
+entry_point: "acl_update.py"
 parameters:
     name:
         type: string
         description: "Name of token"
         required: true
-        position: 0
+        position: 1
     acl_type:
         type: string
         enum:
@@ -18,7 +18,7 @@ parameters:
         default: client
         description: "Type of token"
         required: true
-        position: 1
+        position: 0
     rules:
         type: string
         description: "HCL rules"
@@ -37,5 +37,5 @@ parameters:
         default: ""
     acl_id:
         type: string
-        description: "Consul Policy ID to apply to the token"
-        required: false
+        description: "Consul Policy ID to update."
+        required: true

--- a/actions/agent_checks.py
+++ b/actions/agent_checks.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class ConsulAgentChecksAction(action.ConsulBaseAction):
-    def run(self):
+    def run(self, consul_profile=None):
+        self._create_client(consul_profile)
+
         return (True, self.consul.agent.checks())

--- a/actions/agent_checks.yaml
+++ b/actions/agent_checks.yaml
@@ -3,3 +3,8 @@ runner_type: python-script
 description: "Returns all the checks that are registered with the local agent."
 enabled: true
 entry_point: "agent_checks.py"
+parameters:
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/agent_force_leave.py
+++ b/actions/agent_force_leave.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class ConsulAgentForceLeaveAction(action.ConsulBaseAction):
-    def run(self, node):
+    def run(self, node, consul_profile=None):
+        self._create_client(consul_profile)
+
         return (True, self.consul.agent.force_leave(node))

--- a/actions/agent_force_leave.yaml
+++ b/actions/agent_force_leave.yaml
@@ -8,3 +8,7 @@ parameters:
         type: string
         description: "The node to change state for."
         required: true
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/agent_join.py
+++ b/actions/agent_join.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class ConsulAgentJoinAction(action.ConsulBaseAction):
-    def run(self, address, wan=False):
+    def run(self, address, wan=False, consul_profile=None):
+        self._create_client(consul_profile)
+
         return (True, self.consul.agent.join(address, wan))

--- a/actions/agent_join.yaml
+++ b/actions/agent_join.yaml
@@ -12,4 +12,7 @@ parameters:
         type: boolean
         description: "True: causes the agent to attempt to join using the WAN pool."
         required: false
-
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/agent_maintenance.py
+++ b/actions/agent_maintenance.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class ConsulAgentMaintenanceAction(action.ConsulBaseAction):
-    def run(self, enable=True, reason=None):
+    def run(self, enable=True, reason=None, consul_profile=None):
+        self._create_client(consul_profile)
+
         return (True, self.consul.agent.maintenance(enable, reason))

--- a/actions/agent_maintenance.yaml
+++ b/actions/agent_maintenance.yaml
@@ -1,6 +1,6 @@
 name: agent_maintenance
 runner_type: python-script
-description: "Place the agent into _maintenance mode_."
+description: "Place the agent into 'maintenance mode'."
 enabled: true
 entry_point: "agent_maintenance.py"
 parameters:
@@ -15,3 +15,8 @@ parameters:
         description: "An optional string to aid human operators."
         required: false
         position: 1
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false
+

--- a/actions/agent_members.py
+++ b/actions/agent_members.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class ConsulAgentMembersAction(action.ConsulBaseAction):
-    def run(self, wan=False):
+    def run(self, wan=False, consul_profile=None):
+        self._create_client(consul_profile)
+
         return (True, self.consul.agent.members(wan))

--- a/actions/agent_members.yaml
+++ b/actions/agent_members.yaml
@@ -8,3 +8,7 @@ parameters:
         type: boolean
         description: "Returns the list of WAN members instead of the LAN members."
         required: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/agent_service_deregister.py
+++ b/actions/agent_service_deregister.py
@@ -2,5 +2,6 @@ from lib import action
 
 
 class ConsulServiceDeregisterAction(action.ConsulBaseAction):
-    def run(self, service_id):
+    def run(self, service_id, consul_profile=None):
+        self._create_client(consul_profile)
         return (True, self.consul.agent.service.deregister(service_id=service_id))

--- a/actions/agent_service_deregister.yaml
+++ b/actions/agent_service_deregister.yaml
@@ -8,3 +8,7 @@ parameters:
         type: string
         description: "The id of the service to be removed."
         required: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/agent_service_maintenance.py
+++ b/actions/agent_service_maintenance.py
@@ -2,7 +2,8 @@ from lib import action
 
 
 class ConsulServiceMaintenanceAction(action.ConsulBaseAction):
-    def run(self, service_id, enable, reason=None):
+    def run(self, service_id, enable, reason=None, consul_profile=None):
+        self._create_client(consul_profile)
         return (True, self.consul.agent.service.maintenance(
             service_id=service_id,
             enable=enable,

--- a/actions/agent_service_maintenance.yaml
+++ b/actions/agent_service_maintenance.yaml
@@ -16,3 +16,7 @@ parameters:
         type: string
         description: "An optional string to aid human operators."
         required: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/agent_service_register.py
+++ b/actions/agent_service_register.py
@@ -10,7 +10,9 @@ class ConsulServiceRegisterAction(action.ConsulBaseAction):
             tags=None,
             check=None,
             token=None,
-            enable_tag_override=False):
+            enable_tag_override=False,
+            consul_profile=None):
+        self._create_client(consul_profile)
         return (True, self.consul.agent.service.register(
             name=name,
             service_id=service_id,

--- a/actions/agent_service_register.yaml
+++ b/actions/agent_service_register.yaml
@@ -30,10 +30,16 @@ parameters:
         required: false
     token:
         type: string
+        secret: true
         description: "An optional _ACL token_ to apply to this request."
         required: false
+        default: ""
     enable_tag_override:
         type: boolean
         description: "An optional bool that enable you to modify a service tags from servers(consul agent role server)"
         default: false
+        required: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/agent_services.py
+++ b/actions/agent_services.py
@@ -2,5 +2,6 @@ from lib import action
 
 
 class ConsulAgentServicesAction(action.ConsulBaseAction):
-    def run(self):
+    def run(self, consul_profile=None):
+        self._create_client(consul_profile)
         return (True, self.consul.agent.services())

--- a/actions/agent_services.yaml
+++ b/actions/agent_services.yaml
@@ -3,3 +3,8 @@ runner_type: python-script
 description: "Returns all the services that are registered with the local agent."
 enabled: true
 entry_point: "agent_services.py"
+parameters:
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/catalog_datacenters.py
+++ b/actions/catalog_datacenters.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class ConsulCatalogDataCentersAction(action.ConsulBaseAction):
-    def run(self):
+    def run(self, consul_profile=None):
+        self._create_client(consul_profile)
+
         return (True, self.consul.catalog.datacenters())

--- a/actions/catalog_datacenters.yaml
+++ b/actions/catalog_datacenters.yaml
@@ -3,4 +3,8 @@ runner_type: python-script
 description: "Real-time query of all known datacenters in Consul"
 enabled: true
 entry_point: "catalog_datacenters.py"
-parameters: {}
+parameters:
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/catalog_deregister.py
+++ b/actions/catalog_deregister.py
@@ -2,5 +2,19 @@ from lib import action
 
 
 class ConsulCatalogDeregisterAction(action.ConsulBaseAction):
-    def run(self, node, service, dc):
-        return (True, self.consul.catalog.deregister(node, service, dc=dc))
+    def run(self, node, service=None, check_id=None, dc=None, token=None, consul_profile=None):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        return (
+            True,
+            self.consul.catalog.deregister(
+                node,
+                service_id=service,
+                check_id=check_id,
+                dc=dc,
+                token=token
+            )
+        )

--- a/actions/catalog_deregister.yaml
+++ b/actions/catalog_deregister.yaml
@@ -4,6 +4,16 @@ description: "Deregister an external service in Consul"
 enabled: true
 entry_point: "catalog_deregister.py"
 parameters:
+    token:
+        type: string
+        description: An ACL token to use instead of the agent token.
+        secret: true
+        required: false
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false
     node:
         type: string
         description: "Node Name/ID"
@@ -11,6 +21,10 @@ parameters:
     service:
         type: string
         description: "Service Name/ID"
+        required: false
+    check_id:
+        type: string
+        description: "Check Name/ID"
         required: false
     dc:
         type: string

--- a/actions/catalog_node.py
+++ b/actions/catalog_node.py
@@ -2,9 +2,30 @@ from lib import action
 
 
 class ConsulCatalogNodeAction(action.ConsulBaseAction):
-    def run(self, node, index=None, wait=None, consistency=None, dc=None,
-            token=None):
-        node = self.consul.catalog.node(node, index=index, wait=wait,
-                                        consistency=consistency, dc=dc,
-                                        token=token)
-        return (True, node)
+    def run(
+        self,
+        node,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        token=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+
+        return (
+            True,
+            self.consul.catalog.node(
+                node,
+                index=index,
+                wait=wait,
+                consistency=consistency,
+                dc=dc,
+                token=token
+            )
+        )

--- a/actions/catalog_node.yaml
+++ b/actions/catalog_node.yaml
@@ -27,4 +27,10 @@ parameters:
     token:
         type: string
         description: "An optional _ACL token_ to apply to this request."
+        secret: true
+        required: false
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/catalog_nodes.py
+++ b/actions/catalog_nodes.py
@@ -2,19 +2,31 @@ from lib import action
 
 
 class ConsulCatalogNodesAction(action.ConsulBaseAction):
-    def run(self,
-            index=None,
-            wait=None,
-            consistency=None,
-            dc=None,
-            near=None,
-            token=None):
-
-        return (True, self.consul.catalog.nodes(
-            index=index,
-            wait=wait,
-            consistency=consistency,
-            dc=dc,
-            near=near,
-            token=token
-        ))
+    def run(
+        self,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        near=None,
+        token=None,
+        node_meta=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        return (
+            True,
+            self.consul.catalog.nodes(
+                index=index,
+                wait=wait,
+                consistency=consistency,
+                dc=dc,
+                near=near,
+                token=token,
+                node_meta=node_meta
+            )
+        )

--- a/actions/catalog_nodes.yaml
+++ b/actions/catalog_nodes.yaml
@@ -4,6 +4,16 @@ description: "Return all nodes known about in the *dc* datacenter."
 enabled: true
 entry_point: "catalog_nodes.py"
 parameters:
+    token:
+        type: string
+        description: An ACL token to use instead of the agent token.
+        secret: true
+        required: false
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false
     index:
         type: string
         description: "The current Consul index, suitable for making subsequent calls to wait for changes since this query was last run."
@@ -24,7 +34,8 @@ parameters:
         type: string
         description: "A node name to sort the resulting list in ascending order based on the estimated round trip time from that node."
         required: false
-    token:
-        type: string
-        description: "An optional _ACL token_ to apply to this request."
+    node_meta:
+        type: object
+        description: "An optional meta data used for filtering."
         required: false
+        default: {}

--- a/actions/catalog_register.py
+++ b/actions/catalog_register.py
@@ -2,7 +2,34 @@ from lib import action
 
 
 class ConsulCatalogRegisterAction(action.ConsulBaseAction):
-    def run(self, node, service, address, port, tags, dc):
+    def run(
+        self,
+        node,
+        address,
+        service=None,
+        check=None,
+        dc=None,
+        token=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        if service == {}:
+            service = None
+        if check == {}:
+            check = None
 
-        definition = {"Service": service, "Port": port, "Tags": tags}
-        return (True, self.consul.catalog.register(node, address, service=definition, dc=dc))
+        return (
+            True,
+            self.consul.catalog.register(
+                node,
+                address,
+                service=service,
+                check=check,
+                dc=dc,
+                token=token
+            )
+        )

--- a/actions/catalog_register.yaml
+++ b/actions/catalog_register.yaml
@@ -4,26 +4,34 @@ description: "Register an external service in Consul"
 enabled: true
 entry_point: "catalog_register.py"
 parameters:
+    token:
+        type: string
+        description: An ACL token to use instead of the agent token.
+        secret: true
+        required: false
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false
     node:
         type: string
         description: "Node Name/ID"
-        required: true
-    service:
-        type: string
-        description: "Service Name/ID"
         required: true
     address:
         type: string
         description: "IP Address of the service"
         required: true
-    port:
-        type: integer
-        description: "The Service Port"
-        required: true
-    tags:
-        type: array
-        description: "Optional Array of Tags"
+    service:
+        type: object
+        description: "An option service Service Name/ID"
         required: false
+        default: {}
+    check:
+        type: object
+        description: "An optional check to register."
+        required: false
+        default: {}
     dc:
         type: string
         description: "Optional Data Center ID"

--- a/actions/catalog_service.py
+++ b/actions/catalog_service.py
@@ -2,23 +2,34 @@ from lib import action
 
 
 class ConsulCatalogServiceAction(action.ConsulBaseAction):
-    def run(self,
-            service,
-            index=None,
-            wait=None,
-            tag=None,
-            consistency=None,
-            dc=None,
-            near=None,
-            token=None):
+    def run(
+        self,
+        service,
+        index=None,
+        wait=None,
+        tag=None,
+        consistency=None,
+        dc=None,
+        near=None,
+        token=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
 
-        return (True, self.consul.catalog.service(
-            service=service,
-            index=index,
-            wait=wait,
-            tag=tag,
-            consistency=consistency,
-            dc=dc,
-            near=near,
-            token=token
-        ))
+        return (
+            True,
+            self.consul.catalog.service(
+                service=service,
+                index=index,
+                wait=wait,
+                tag=tag,
+                consistency=consistency,
+                dc=dc,
+                near=near,
+                token=token
+            )
+        )

--- a/actions/catalog_service.yaml
+++ b/actions/catalog_service.yaml
@@ -4,6 +4,16 @@ description: "Returns the nodes providing *service* in the *dc* datacenter."
 enabled: true
 entry_point: "catalog_service.py"
 parameters:
+    token:
+        type: string
+        description: An ACL token to use instead of the agent token.
+        required: false
+        secret: true
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false
     service:
         type: string
         description: "The service to query for nodes."
@@ -31,8 +41,4 @@ parameters:
     near:
         type: string
         description: "A node name to sort the resulting list in ascending order based on the estimated round trip time from that node."
-        required: false
-    token:
-        type: string
-        description: "An optional _ACL token_ to apply to this request."
         required: false

--- a/actions/catalog_services.py
+++ b/actions/catalog_services.py
@@ -2,16 +2,31 @@ from lib import action
 
 
 class ConsulCatalogServicesAction(action.ConsulBaseAction):
-    def run(self,
-            index=None,
-            wait=None,
-            consistency=None,
-            dc=None,
-            token=None):
-
-        return (True, self.consul.catalog.services(
-            index=index,
-            wait=wait,
-            consistency=consistency,
-            dc=dc,
-            token=token))
+    def run(
+        self,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        token=None,
+        node_meta=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        if node_meta == {}:
+            node_meta = None
+        return (
+            True,
+            self.consul.catalog.services(
+                index=index,
+                wait=wait,
+                consistency=consistency,
+                dc=dc,
+                token=token,
+                node_meta=node_meta
+            )
+        )

--- a/actions/catalog_services.yaml
+++ b/actions/catalog_services.yaml
@@ -4,6 +4,16 @@ description: "Returns all services known about in the *dc* datacenter."
 enabled: true
 entry_point: "catalog_services.py"
 parameters:
+    token:
+        type: string
+        description: An ACL token to use instead of the agent token.
+        secret: true
+        required: false
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false
     index:
         type: integer
         description: "The current Consul index. Used to check for changes since last query was run."
@@ -24,8 +34,8 @@ parameters:
         type: string
         description: "The datacenter that this agent will communicate with."
         required: false
-    token:
-        type: string
-        description: "An optional ACL token to apply to this request."
-        secret: true
+    node_meta:
+        type: object
+        description: "An optional meta data used for filtering."
         required: false
+        default: {}

--- a/actions/custom_lock.py
+++ b/actions/custom_lock.py
@@ -7,7 +7,24 @@ class ConsulCustomLockAction(action.ConsulBaseAction):
     :max_locks: (integer) Maximum number of concurrent lock holders.
     :name: (string) Name of the key that will hold the locking information.
     """
-    def run(self, key_prefix, max_locks=1, acquire_timeout=10, name="CustomLock",
-            node=None, checks=None, behavior="release", ttl=None, token=None, dc=None):
+    def run(
+        self,
+        key_prefix,
+        max_locks=1,
+        acquire_timeout=10,
+        name="CustomLock",
+        node=None,
+        checks=None,
+        behavior="release",
+        ttl=None,
+        token=None,
+        dc=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
         self.lock_manager = action.LockManager(self.consul, key_prefix, name, node, token, dc)
         return self.lock_manager.lock(max_locks, acquire_timeout, checks, behavior, ttl)

--- a/actions/custom_lock.yaml
+++ b/actions/custom_lock.yaml
@@ -46,7 +46,13 @@ parameters:
         type: string
         description: An optional ACL token to apply to this request.
         required: false
+        secret: true
+        default: ""
     dc:
         type: string
         description: Optional datacenter that you wish to communicate with.
+        required: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/custom_unlock.py
+++ b/actions/custom_unlock.py
@@ -7,6 +7,20 @@ class ConsulCustomUnLockAction(action.ConsulBaseAction):
     :key_prefix: (string) Prefix the lock name which is the path in consul's kvstore.
     :name: (string) Name of the key that will hold the locking information.
     """
-    def run(self, session_id, key_prefix, name, node=None, token=None, dc=None):
+    def run(
+        self,
+        session_id,
+        key_prefix,
+        name,
+        node=None,
+        token=None,
+        dc=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
         self.lock_manager = action.LockManager(self.consul, key_prefix, name, node, token, dc)
         return self.lock_manager.unlock(session_id)

--- a/actions/custom_unlock.yaml
+++ b/actions/custom_unlock.yaml
@@ -24,7 +24,12 @@ parameters:
         type: string
         description: An optional ACL token to apply to this request.
         required: false
+        default: ""
     dc:
         type: string
         description: Optional datacenter that you wish to communicate with.
+        required: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/event_fire.py
+++ b/actions/event_fire.py
@@ -2,19 +2,33 @@ from lib import action
 
 
 class ConsulEventFireAction(action.ConsulBaseAction):
-    def run(self,
-            name,
-            body="",
-            node=None,
-            service=None,
-            tag=None):
+    def run(
+        self,
+        name,
+        body="",
+        node=None,
+        service=None,
+        tag=None,
+        token=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
 
         if len(body) > 100:
             self.logger.warn("Event body being fired exceeds the recommended 100 byte limit!")
 
-        return (True, self.consul.event.fire(
-            name=name,
-            body=body,
-            node=node,
-            service=service,
-            tag=tag))
+        return (
+            True,
+            self.consul.event.fire(
+                name=name,
+                body=body,
+                node=node,
+                service=service,
+                tag=tag,
+                token=token
+            )
+        )

--- a/actions/event_fire.yaml
+++ b/actions/event_fire.yaml
@@ -6,7 +6,6 @@ entry_point: "event_fire.py"
 parameters:
     name:
         type: string
-        type: string
         description: "Key to write in Consul"
         required: true
     body:
@@ -24,4 +23,14 @@ parameters:
     tag:
         type: string
         description: "A Regex which remote agents will filter against to determine if they should store the event."
+        required: false
+    token:
+        type: string
+        description: An ACL token to use instead of the agent token.
+        secret: true
+        required: false
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/event_list.py
+++ b/actions/event_list.py
@@ -2,15 +2,11 @@ from lib import action
 
 
 class ConsulEventListAction(action.ConsulBaseAction):
-    def run(self,
-            name=None,
-            index=None,
-            wait=None):
+    def run(self, name=None, index=None, wait=None, consul_profile=None):
+
+        self._create_client(consul_profile)
 
         if name == "":
             name = None
 
-        return (True, self.consul.event.list(
-            name=name,
-            index=index,
-            wait=wait))
+        return (True, self.consul.event.list(name=name, index=index, wait=wait))

--- a/actions/event_list.yaml
+++ b/actions/event_list.yaml
@@ -17,3 +17,7 @@ parameters:
         type: string
         description: "The maximum duration to wait (e.g. '10s') to retrieve a given index."
         required: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/health_checks.py
+++ b/actions/health_checks.py
@@ -2,18 +2,33 @@ from lib import action
 
 
 class ConsulHealthChecksAction(action.ConsulBaseAction):
-    def run(self,
-            service,
-            index=None,
-            wait=None,
-            dc=None,
-            near=None,
-            token=None):
-
-        return (True, self.consul.health.checks(
-            service,
-            index=index,
-            wait=wait,
-            dc=dc,
-            near=near,
-            token=token))
+    def run(
+        self,
+        service,
+        index=None,
+        wait=None,
+        dc=None,
+        near=None,
+        token=None,
+        node_meta=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        if node_meta == {}:
+            node_meta = None
+        return (
+            True,
+            self.consul.health.checks(
+                service,
+                index=index,
+                wait=wait,
+                dc=dc,
+                near=near,
+                token=token,
+                node_meta=node_meta
+            )
+        )

--- a/actions/health_checks.yaml
+++ b/actions/health_checks.yaml
@@ -29,3 +29,13 @@ parameters:
         description: "An optional ACL token to apply to this request."
         secret: true
         required: false
+        default: ""
+    node_meta:
+        type: object
+        description: "An optional meta data used for filtering."
+        required: false
+        default: {}
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/health_node.py
+++ b/actions/health_node.py
@@ -2,16 +2,27 @@ from lib import action
 
 
 class ConsulHealthNodeAction(action.ConsulBaseAction):
-    def run(self,
-            node,
-            index=None,
-            wait=None,
-            dc=None,
-            token=None):
-
-        return (True, self.consul.health.node(
-            node,
-            index=index,
-            wait=wait,
-            dc=dc,
-            token=token))
+    def run(
+        self,
+        node,
+        index=None,
+        wait=None,
+        dc=None,
+        token=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        return (
+            True,
+            self.consul.health.node(
+                node,
+                index=index,
+                wait=wait,
+                dc=dc,
+                token=token
+            )
+        )

--- a/actions/health_node.yaml
+++ b/actions/health_node.yaml
@@ -22,6 +22,11 @@ parameters:
         required: false
     token:
         type: string
-        description: "An optional ACL token to apply to this request."
+        description: "An ACL token to use instead of the agent token."
+        required: false
         secret: true
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/health_service.py
+++ b/actions/health_service.py
@@ -2,22 +2,36 @@ from lib import action
 
 
 class ConsulHealthServiceAction(action.ConsulBaseAction):
-    def run(self,
-            service,
-            index=None,
-            wait=None,
-            passing=None,
-            tag=None,
-            dc=None,
-            near=None,
-            token=None):
+    def run(
+        self,
+        service,
+        index=None,
+        wait=None,
+        passing=None,
+        tag=None,
+        dc=None,
+        near=None,
+        token=None,
+        node_meta=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
 
-        return (True, self.consul.health.service(
-            service,
-            index=index,
-            wait=wait,
-            passing=passing,
-            tag=tag,
-            dc=dc,
-            near=near,
-            token=token))
+        return (
+            True,
+            self.consul.health.service(
+                service,
+                index=index,
+                wait=wait,
+                passing=passing,
+                tag=tag,
+                dc=dc,
+                near=near,
+                token=token,
+                node_meta=node_meta
+            )
+        )

--- a/actions/health_service.yaml
+++ b/actions/health_service.yaml
@@ -34,6 +34,16 @@ parameters:
         required: false
     token:
         type: string
-        description: "An optional ACL token to apply to this request."
+        description: "An ACL token to use instead of the agent token."
+        required: false
         secret: true
+        default: ""
+    node_meta:
+        type: object
+        description: "An optional meta data used for filtering."
+        required: false
+        default: {}
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/health_state.py
+++ b/actions/health_state.py
@@ -2,18 +2,31 @@ from lib import action
 
 
 class ConsulHealthStateAction(action.ConsulBaseAction):
-    def run(self,
-            name,
-            index=None,
-            wait=None,
-            dc=None,
-            near=None,
-            token=None):
-
-        return (True, self.consul.health.state(
-            name,
-            index=index,
-            wait=wait,
-            dc=dc,
-            near=near,
-            token=token))
+    def run(
+        self,
+        name,
+        index=None,
+        wait=None,
+        dc=None,
+        near=None,
+        token=None,
+        node_meta=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        return (
+            True,
+            self.consul.health.state(
+                name,
+                index=index,
+                wait=wait,
+                dc=dc,
+                near=near,
+                token=token,
+                node_meta=node_meta
+            )
+        )

--- a/actions/health_state.yaml
+++ b/actions/health_state.yaml
@@ -36,3 +36,13 @@ parameters:
         description: "An optional ACL token to apply to this request."
         secret: true
         required: false
+        default: ""
+    node_meta:
+        type: object
+        description: "An optional meta data used for filtering."
+        required: false
+        default: {}
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/kv_delete.py
+++ b/actions/kv_delete.py
@@ -2,11 +2,19 @@ from lib import action
 
 
 class ConsulKVDeleteAction(action.ConsulBaseAction):
-    def run(self, key, recurse=None, cas=None, token=None, dc=None):
-        return (True, self.consul.kv.delete(
-            key,
-            recurse=recurse,
-            cas=cas,
-            token=token,
-            dc=dc
-        ))
+    def run(self, key, recurse=None, cas=None, token=None, dc=None, consul_profile=None):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        return (
+            True,
+            self.consul.kv.delete(
+                key,
+                recurse=recurse,
+                cas=cas,
+                token=token,
+                dc=dc
+            )
+        )

--- a/actions/kv_delete.yaml
+++ b/actions/kv_delete.yaml
@@ -18,11 +18,17 @@ parameters:
         type: integer
         description: An optional flag is used to turn the DELETE into a Check-And-Set operation.
         required: false
-    token:
-        type: string
-        description: An optional ACL token to apply to this request.
-        required: false
     dc:
         type: string
         description: Optional datacenter that you wish to communicate with.
+        required: false
+    token:
+        type: string
+        description: "An ACL token to use instead of the agent token."
+        required: false
+        secret: true
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false

--- a/actions/kv_get.py
+++ b/actions/kv_get.py
@@ -1,28 +1,38 @@
+from __future__ import absolute_import
 from lib import action
 
 
 class ConsulKVGetAction(action.ConsulBaseAction):
-    def run(self,
+    def run(
+        self,
+        key,
+        index=None,
+        recurse=False,
+        wait=None,
+        token=None,
+        consistency=None,
+        keys=False,
+        separator=None,
+        dc=None,
+        from_json=False,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
+        idx, res = self.consul.kv.get(
             key,
-            index=None,
-            recurse=False,
-            wait=None,
-            token=None,
-            consistency=None,
-            keys=False,
-            separator=None,
-            dc=None,
-            from_json=False):
-
-        idx, res = self.consul.kv.get(key,
-                                      index=index,
-                                      recurse=recurse,
-                                      wait=wait,
-                                      token=token,
-                                      consistency=consistency,
-                                      keys=keys,
-                                      separator=separator,
-                                      dc=dc)
+            index=index,
+            recurse=recurse,
+            wait=wait,
+            token=token,
+            consistency=consistency,
+            keys=keys,
+            separator=separator,
+            dc=dc
+        )
 
         if from_json and not keys:
             if isinstance(res, dict):

--- a/actions/kv_get.yaml
+++ b/actions/kv_get.yaml
@@ -23,7 +23,13 @@ parameters:
         required: false
     token:
         type: string
-        description: "An optional ACL token to apply to this request."
+        description: "An ACL token to use instead of the agent token."
+        required: false
+        secret: true
+        default: ""
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
         required: false
     consistency:
         type: string

--- a/actions/kv_list.yaml
+++ b/actions/kv_list.yaml
@@ -18,3 +18,7 @@ parameters:
         description: "Return a list of keys only"
         required: false
         default: true
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/kv_put.py
+++ b/actions/kv_put.py
@@ -2,16 +2,24 @@ from lib import action
 
 
 class ConsulKVPutAction(action.ConsulBaseAction):
-    def run(self,
-            key,
-            value,
-            cas=None,
-            flags=None,
-            acquire=None,
-            release=None,
-            token=None,
-            dc=None,
-            to_json=False):
+    def run(
+        self,
+        key,
+        value,
+        cas=None,
+        flags=None,
+        acquire=None,
+        release=None,
+        token=None,
+        dc=None,
+        to_json=False,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
+        # Action parameter "token" defaults to an empty string when no input is provided.
+        # Consul-Python tests for None to use the agent's token, so "token" set to None here.
+        if token == "":
+            token = None
 
         if to_json:
             value = self.to_json(value)

--- a/actions/kv_put.yaml
+++ b/actions/kv_put.yaml
@@ -30,8 +30,10 @@ parameters:
         required: false
     token:
         type: string
-        description: An optional ACL token to apply to this request.
+        description: "An ACL token to use instead of the agent token."
         required: false
+        secret: true
+        default: ""
     dc:
         type: string
         description: Optional datacenter that you wish to communicate with.
@@ -41,3 +43,7 @@ parameters:
         description: "Serialise value to JSON before storing in consul k/v"
         required: false
         default: false
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -20,7 +20,6 @@ class ConsulBaseAction(Action):
         # Delay the creation of the Consul client to be able to read the consul profile to use.
         self.consul = None
 
-
     def _get_pack_configuration(self, profile=None):
         """
         Fetch the variables from the pack configuration.

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -2,6 +2,7 @@ import six
 import json
 import random
 import time
+import os
 
 from st2common import log as logging
 from st2common.runners.base_action import Action
@@ -16,25 +17,59 @@ class ConsulBaseAction(Action):
 
     def __init__(self, config):
         super(ConsulBaseAction, self).__init__(config)
-        self.consul = self._get_client()
+        # Delay the creation of the Consul client to be able to read the consul profile to use.
+        self.consul = None
 
-    def _get_client(self):
-        dc = self.config.get('dc')
-        host = self.config.get('host')
-        port = self.config.get('port')
-        token = self.config.get('token')
-        scheme = self.config.get('scheme')
-        verify = self.config.get('verify')
-        consistency = self.config.get('consistency') or 'default'
 
-        client = consul.Consul(host, port, token, scheme, consistency, dc, verify)
-        return client
+    def _get_pack_configuration(self, profile=None):
+        """
+        Fetch the variables from the pack configuration.
+        """
+        for env_key in os.environ:
+            if "CONSUL" in env_key:
+                print("{}={}".format(env_key, os.environ[env_key]))
+                del os.environ[env_key]
+        profile = self.config["consul_profiles"].get(profile, None)
+        if profile is None:
+            raise ValueError("A valid Consul profile must be supplied.")
+        self.dc = profile.get("dc")
+        self.host = profile.get("host")
+        self.port = profile.get("port")
+        self.token = profile.get("token")
+        self.scheme = profile.get("scheme")
+        self.client_cert_path = profile.get("client_cert_path")
+        self.client_key_path = profile.get("client_key_path")
+        self.cert = (self.client_cert_path, self.client_key_path)
+        self.verify = profile.get("verify")
+        self.ca_cert_path = profile.get("ca_cert_path", "")
+        # Python Requests supports boolean or a file path for the verify agrument.
+        if self.ca_cert_path != "":
+            self.verify = self.ca_cert_path
+        self.consistency = profile.get("consistency", "default")
+
+    def _create_client(self, profile=None):
+        # Attempt to get the default profile from the config if the action didn't supply one.
+        if profile is None:
+            profile = self.config.get("default_profile", None)
+
+        self._get_pack_configuration(profile)
+
+        self.consul = consul.Consul(
+            self.host,
+            self.port,
+            self.token,
+            self.scheme,
+            self.consistency,
+            self.dc,
+            self.verify,
+            self.cert
+        )
 
     def to_json(self, value):
         """
         Unescape StackStorm string and push as a json serialised object into consul.
         """
-        return json.dumps(json.loads(value.decode('string_escape')))
+        return json.dumps(json.loads(value.decode("string_escape")))
 
     def from_json(self, value):
         """
@@ -78,14 +113,14 @@ class LockManager(object):
         if self.max_locks > 1:
             result = self.create_semaphore()
         else:
-            result = self.create_lock("/".join([self.key_prefix, self.name, '.lock']))
+            result = self.create_lock("/".join([self.key_prefix, self.name, ".lock"]))
         return result
 
     def unlock(self, session_id):
         """
         Method called by the Unlock action.
         """
-        key = "/".join([self.key_prefix, self.name, '.lock'])
+        key = "/".join([self.key_prefix, self.name, ".lock"])
         return self.release_lock(key, session_id)
 
     def create_semaphore(self):
@@ -110,7 +145,7 @@ class LockManager(object):
         return result
 
     def destroy_session(self, session_id):
-        self.client.session.destroy(session_id, self.dc)
+        return self.client.session.destroy(session_id, self.dc)
 
     def create_lock(self, key_name):
         result = (False, "")

--- a/actions/session_create.py
+++ b/actions/session_create.py
@@ -2,20 +2,28 @@ from lib import action
 
 
 class ConsulSessionCreateAction(action.ConsulBaseAction):
-    def run(self,
-            name=None,
-            node=None,
-            checks=None,
-            lock_delay=15,
-            behavior='release',
-            ttl=None,
-            dc=None):
+    def run(
+        self,
+        name=None,
+        node=None,
+        checks=None,
+        lock_delay=15,
+        behavior='release',
+        ttl=None,
+        dc=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
 
-        return (True, self.consul.session.create(
-            name=name,
-            node=node,
-            checks=checks,
-            lock_delay=lock_delay,
-            behavior=behavior,
-            ttl=ttl,
-            dc=dc))
+        return (
+            True,
+            self.consul.session.create(
+                name=name,
+                node=node,
+                checks=checks,
+                lock_delay=lock_delay,
+                behavior=behavior,
+                ttl=ttl,
+                dc=dc
+            )
+        )

--- a/actions/session_create.yaml
+++ b/actions/session_create.yaml
@@ -46,4 +46,7 @@ parameters:
         description: "The datacenter that this agent will communicate with."
         required: false
         position: 6
-
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/session_destroy.py
+++ b/actions/session_destroy.py
@@ -2,5 +2,6 @@ from lib import action
 
 
 class ConsulSessionDestroyAction(action.ConsulBaseAction):
-    def run(self, session_id, dc=None):
+    def run(self, session_id, dc=None, consul_profile=None):
+        self._create_client(consul_profile)
         return (True, self.consul.session.destroy(session_id, dc=dc))

--- a/actions/session_destroy.yaml
+++ b/actions/session_destroy.yaml
@@ -15,4 +15,7 @@ parameters:
         description: "dc is the datacenter that this agent will communicate with."
         required: false
         position: 1
-
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/session_info.py
+++ b/actions/session_info.py
@@ -2,11 +2,24 @@ from lib import action
 
 
 class ConsulSessionInfoAction(action.ConsulBaseAction):
-    def run(self, session_id, index=None, wait=None, consistency=None, dc=None):
+    def run(
+        self,
+        session_id,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        consul_profile=None
+    ):
+        self._create_client(consul_profile)
 
-        return (True, self.consul.session.info(
-            session_id,
-            index=index,
-            wait=wait,
-            consistency=consistency,
-            dc=dc))
+        return (
+            True,
+            self.consul.session.info(
+                session_id,
+                index=index,
+                wait=wait,
+                consistency=consistency,
+                dc=dc
+            )
+        )

--- a/actions/session_info.yaml
+++ b/actions/session_info.yaml
@@ -35,3 +35,7 @@ parameters:
         description: "The datacenter that this agent will communicate with."
         required: false
         position: 4
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/session_list.py
+++ b/actions/session_list.py
@@ -2,10 +2,22 @@ from lib import action
 
 
 class ConsulSessionListAction(action.ConsulBaseAction):
-    def run(self, index=None, wait=None, consistency=None, dc=None):
+    def run(
+        self,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        consul_profile=None,
+    ):
+        self._create_client(consul_profile)
 
-        return (True, self.consul.session.list(
-            index=index,
-            wait=wait,
-            consistency=consistency,
-            dc=dc))
+        return (
+            True,
+            self.consul.session.list(
+                index=index,
+                wait=wait,
+                consistency=consistency,
+                dc=dc
+            )
+        )

--- a/actions/session_list.yaml
+++ b/actions/session_list.yaml
@@ -30,3 +30,7 @@ parameters:
         description: "The datacenter that this agent will communicate with."
         required: false
         position: 3
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/session_node.py
+++ b/actions/session_node.py
@@ -2,12 +2,17 @@ from lib import action
 
 
 class ConsulSessionNodeAction(action.ConsulBaseAction):
-    def run(self, node, index=None, wait=None, consistency=None, dc=None):
+    def run(self, node, index=None, wait=None, consistency=None, dc=None, consul_profile=None):
 
-        return (True, self.consul.session.node(
-            node,
-            index=index,
-            wait=wait,
-            consistency=consistency,
-            dc=dc
-        ))
+        self._create_client(consul_profile)
+
+        return (
+            True,
+            self.consul.session.node(
+                node,
+                index=index,
+                wait=wait,
+                consistency=consistency,
+                dc=dc
+            )
+        )

--- a/actions/session_node.yaml
+++ b/actions/session_node.yaml
@@ -35,3 +35,7 @@ parameters:
         description: "The datacenter that this agent will communicate with."
         required: false
         position: 4
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/session_renew.py
+++ b/actions/session_renew.py
@@ -2,6 +2,13 @@ from lib import action
 
 
 class ConsulSessionRenewAction(action.ConsulBaseAction):
-    def run(self, session_id, dc=None):
-        session = self.consul.session.renew(session_id, dc=dc)
-        return (True, session)
+    def run(self, session_id, dc=None, consul_profile=None):
+        self._create_client(consul_profile)
+
+        return (
+            True,
+            self.consul.session.renew(
+                session_id,
+                dc=dc
+            )
+        )

--- a/actions/session_renew.yaml
+++ b/actions/session_renew.yaml
@@ -15,4 +15,7 @@ parameters:
         description: "The datacenter that this agent will communicate with."
         required: false
         position: 1
-
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/test_pack_actions.yaml
+++ b/actions/test_pack_actions.yaml
@@ -1,0 +1,11 @@
+name: test_pack_actions
+pack: consul
+runner_type: orquesta
+description: Test all actions in the consul pack.
+enabled: true
+entry_point: workflows/test_pack_actions.yaml
+parameters:
+    consul_profile:
+        type: string
+        description: "Consul profile to use to run the action."
+        required: false

--- a/actions/workflows/test_pack_actions.yaml
+++ b/actions/workflows/test_pack_actions.yaml
@@ -1,0 +1,353 @@
+version: 1.0
+
+description: A basic workflow that runs an arbitrary linux command.
+
+input:
+  - consul_profile
+
+tasks:
+    test_acl_create:
+        action: consul.acl_create
+        input:
+            name: test_name
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            -
+                publish:
+                    - acl_id: <% result().result %>
+                do: test_acl_info
+
+    test_acl_info:
+        action: consul.acl_info
+        input:
+            acl_id: <% ctx(acl_id) %>
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_acl_clone
+
+    test_acl_clone:
+        action: consul.acl_clone
+        input:
+            acl_id: <% ctx(acl_id) %>
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            -
+                publish:
+                    - cloned_acl_id: <% result().result %>
+                do: test_acl_update
+
+    test_acl_update:
+        action: consul.acl_update
+        input:
+            name: test_name2
+            acl_id: <% ctx(acl_id) %>
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_acl_destroy
+
+    test_acl_destroy:
+        action: consul.acl_destroy
+        input:
+            acl_id: <% ctx(acl_id) %>
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_acl_destroy_clone
+
+    test_acl_destroy_clone:
+        action: consul.acl_destroy
+        input:
+            acl_id: <% ctx(cloned_acl_id) %>
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_acl_list
+
+    test_acl_list:
+        action: consul.acl_list
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_checks
+
+    test_agent_checks:
+        action: consul.agent_checks
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_force_leave
+
+    test_agent_force_leave:
+        action: consul.agent_force_leave
+        input:
+            node: test_node
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_join
+
+    test_agent_join:
+        action: consul.agent_join
+        input:
+            address: 127.0.0.1
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_maintenance
+
+    test_agent_maintenance:
+        action: consul.agent_maintenance
+        input:
+            enable: true
+            reason: test_maintenance
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_members
+
+    test_agent_members:
+        action: consul.agent_members
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_service_register
+
+    test_agent_service_register:
+        action: consul.service_register
+        input:
+            name: test_service
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_enable_service_maintenance
+
+    test_agent_enable_service_maintenance:
+        action: consul.service_maintenance
+        input:
+            service_id: test_service
+            enable: true
+            reason: test_service_maintenance
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_disable_service_maintenance
+
+    test_agent_disable_service_maintenance:
+        action: consul.service_maintenance
+        input:
+            service_id: test_service
+            enable: false
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_service_deregister
+
+    test_agent_service_deregister:
+        action: consul.service_deregister
+        input:
+            service_id: test_service
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_agent_services
+
+
+    test_agent_services:
+        action: consul.agent_services
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_catalog_datacenters
+
+    test_catalog_datacenters:
+        action: consul.catalog_datacenters
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_catalog_deregister
+
+    test_catalog_deregister:
+        action: consul.catalog_deregister
+        input:
+            node: test_node
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_catalog_node
+
+    test_catalog_node:
+        action: consul.catalog_node
+        input:
+            node: test_node
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_catalog_nodes
+
+    test_catalog_nodes:
+        action: consul.catalog_nodes
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_catalog_register
+
+    test_catalog_register:
+        action: consul.catalog_register
+        input:
+            node: test_node
+            address: 127.0.0.1
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_catalog_service
+
+    test_catalog_service:
+        action: consul.catalog_service
+        input:
+            service: test_service
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_catalog_services
+
+    test_catalog_services:
+        action: consul.catalog_services
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_custom_lock
+
+    test_custom_lock:
+        action: consul.custom_lock
+        input:
+            key_prefix: test_key_prefix
+            name: test_lock
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_custom_unlock
+
+    test_custom_unlock:
+        action: consul.custom_unlock
+        input:
+            session_id: test_session_id
+            key_prefix: test_key_prefix
+            name: test_lock
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_event_fire
+
+    test_event_fire:
+        action: consul.event_fire
+        input:
+            name: test_name
+            body: "{}"
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_event_list
+
+    test_event_list:
+        action: consul.event_list
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_health_checks
+
+    test_health_checks:
+        action: consul.health_checks
+        input:
+            service: test_service
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_health_node
+
+    test_health_node:
+        action: consul.health_node
+        input:
+            node: test_node
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_health_service
+
+    test_health_service:
+        action: consul.health_service
+        input:
+            service: test_service
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_health_state
+
+    test_health_state:
+        action: consul.health_state
+        input:
+            name: any
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_kv_delete
+
+    test_kv_delete:
+        action: consul.kv_delete
+        input:
+            key: test_key
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_kv_get
+
+    test_kv_get:
+        action: consul.kv_get
+        input:
+            key: test_key
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_kv_list
+
+    test_kv_list:
+        action: consul.kv_list
+        input:
+            key: test_key
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_kv_put
+
+    test_kv_put:
+        action: consul.kv_put
+        input:
+            key: test_key
+            value: test_value
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_session_create
+
+    test_session_create:
+        action: consul.session_create
+        input:
+            name: test_session
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            -
+                publish:
+                    - session_id: <% result().result %>
+                do: test_session_info
+
+    test_session_info:
+        action: consul.session_info
+        input:
+            session_id: <% ctx(session_id) %>
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_session_list
+
+    test_session_list:
+        action: consul.session_list
+        input:
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_session_node
+
+    test_session_node:
+        action: consul.session_node
+        input:
+            node: test_node
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_session_renew
+
+    test_session_renew:
+        action: consul.session_renew
+        input:
+            session_id: <% ctx(session_id) %>
+            consul_profile: <% ctx(consul_profile) %>
+        next:
+            - do: test_session_destroy
+
+    test_session_destroy:
+        action: consul.session_destroy
+        input:
+            session_id: <% ctx(session_id) %>
+            consul_profile: <% ctx(consul_profile) %>

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,37 +1,64 @@
 ---
-  host:
-    description: "Consul server IP/name.  Default 127.0.0.1"
-    type: "string"
-    secret: false
+default_profile:
+  description: "The default consul profile to use in actions when none is given."
+  type: string
+  required: true
+consul_profiles:
+  description: "Consul cluster profiles"
+  type: "object"
+  required: true
+  items:
+    type: "object"
     required: true
-    default: "127.0.0.1"
-  port:
-    description: "Consul server port. Default 8500"
-    type: "integer"
-    secret: false
-    required: true
-    default: 8500
-  token:
-    description: "Consul API token"
-    type: "string"
-    secret: true
-    required: true
-  scheme:
-    description: "Consul scheme to use. Default http"
-    type: "string"
-    required: false
-    default: "http"
-  verify:
-    description: "Verify the SSL certificate for HTTPS requests. Default false"
-    type: "boolean"
-    required: false
-    default: false
-  consistency:
-    description: "The consistency mode to use by default for all reads that support the consistency option."
-    type: "string"
-    enum:
-      - default
-      - consistent
-      - stale
-    required: false
-    default: "default"
+    properties:
+      host:
+        description: "Consul server IP/name.  Default 127.0.0.1"
+        type: "string"
+        secret: false
+        required: true
+        default: "127.0.0.1"
+      port:
+        description: "Consul server port. Default 8500"
+        type: "integer"
+        secret: false
+        required: true
+        default: 8500
+      token:
+        description: "Consul API token"
+        type: "string"
+        secret: true
+        required: true
+        default: ""
+      scheme:
+        description: "Consul scheme to use. Default http"
+        type: "string"
+        required: false
+        default: "http"
+      verify:
+        description: "Verify the SSL certificate for HTTPS requests. Default false (this option is ignored if ca_cert_path is supplied)."
+        type: "boolean"
+        required: false
+        default: false
+      ca_cert_path:
+        description: "CA Certificate path. Defaults to empty string. When path is provided, SSL certificates are verified."
+        type: "string"
+        required: false
+        default: ""
+      client_cert_path:
+        description: "Client side certificates for HTTPS request"
+        type: "string"
+        required: false
+      client_key_path:
+        description: "Client private key for HTTPS request"
+        type: "string"
+        required: false
+      consistency:
+        description: "The consistency mode to use by default for all reads that support the consistency option."
+        type: "string"
+        enum:
+          - default
+          - consistent
+          - stale
+        required: false
+        default: "default"
+

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -5,12 +5,17 @@ default_profile:
   required: true
 consul_profiles:
   description: "Consul cluster profiles"
-  type: "object"
+  type: "array"
   required: true
   items:
     type: "object"
     required: true
+    additionalProperties: false
     properties:
+      name:
+        description: "Name of the consul profile."
+        type: "string"
+        required: true
       host:
         description: "Consul server IP/name.  Default 127.0.0.1"
         type: "string"
@@ -52,6 +57,11 @@ consul_profiles:
         description: "Client private key for HTTPS request"
         type: "string"
         required: false
+      preserve_varenv:
+        description: "Enable preservation of environment variables.  If disable, all CONSUL_* environment variables are deleted from the action execution."
+        type: boolean
+        requried: false
+        default: true
       consistency:
         description: "The consistency mode to use by default for all reads that support the consistency option."
         type: "string"

--- a/consul.yaml.example
+++ b/consul.yaml.example
@@ -1,6 +1,5 @@
 ----
 consul_profiles:
-  -
     production:
       ca_cert_path: /etc/ssl/certs/ca.pem
       client_cert_path: /etc/ssl/certs/client-cert.pem
@@ -11,7 +10,6 @@ consul_profiles:
       scheme: https
       token: 11111111-bbbb-aaaa-cccc-222222222222
       verify: true
-  -
     dev:
       ca_cert_path: /etc/ssl/certs/dev-ca.pem
       client_cert_path: /etc/ssl/certs/dev-client-cert.pem

--- a/consul.yaml.example
+++ b/consul.yaml.example
@@ -1,23 +1,25 @@
 ----
 consul_profiles:
-  production:
-    ca_cert_path: /etc/ssl/certs/ca.pem
-    client_cert_path: /etc/ssl/certs/client-cert.pem
-    client_key_path: /etc/ssl/private/client-key.pem
-    consistency: default
-    host: 127.0.0.1
-    port: 8500
-    scheme: https
-    token: 11111111-bbbb-aaaa-cccc-222222222222
-    verify: true
-  dev:
-    ca_cert_path: /etc/ssl/certs/dev-ca.pem
-    client_cert_path: /etc/ssl/certs/dev-client-cert.pem
-    client_key_path: /etc/ssl/private/dev-client-key.pem
-    consistency: default
-    host: 10.11.12.13
-    port: 8500
-    scheme: https
-    token: 22222222-bbbb-aaaa-cccc-444444444444
-    verify: false
+  -
+    production:
+      ca_cert_path: /etc/ssl/certs/ca.pem
+      client_cert_path: /etc/ssl/certs/client-cert.pem
+      client_key_path: /etc/ssl/private/client-key.pem
+      consistency: default
+      host: 127.0.0.1
+      port: 8500
+      scheme: https
+      token: 11111111-bbbb-aaaa-cccc-222222222222
+      verify: true
+  -
+    dev:
+      ca_cert_path: /etc/ssl/certs/dev-ca.pem
+      client_cert_path: /etc/ssl/certs/dev-client-cert.pem
+      client_key_path: /etc/ssl/private/dev-client-key.pem
+      consistency: default
+      host: 10.11.12.13
+      port: 8500
+      scheme: https
+      token: 22222222-bbbb-aaaa-cccc-444444444444
+      verify: false
 default_profile: production

--- a/consul.yaml.example
+++ b/consul.yaml.example
@@ -1,4 +1,23 @@
----
-host: '127.0.0.1'
-port: 8500
-token: ''
+----
+consul_profiles:
+  production:
+    ca_cert_path: /etc/ssl/certs/ca.pem
+    client_cert_path: /etc/ssl/certs/client-cert.pem
+    client_key_path: /etc/ssl/private/client-key.pem
+    consistency: default
+    host: 127.0.0.1
+    port: 8500
+    scheme: https
+    token: 11111111-bbbb-aaaa-cccc-222222222222
+    verify: true
+  dev:
+    ca_cert_path: /etc/ssl/certs/dev-ca.pem
+    client_cert_path: /etc/ssl/certs/dev-client-cert.pem
+    client_key_path: /etc/ssl/private/dev-client-key.pem
+    consistency: default
+    host: 10.11.12.13
+    port: 8500
+    scheme: https
+    token: 22222222-bbbb-aaaa-cccc-444444444444
+    verify: false
+default_profile: production

--- a/consul.yaml.example
+++ b/consul.yaml.example
@@ -1,7 +1,7 @@
 ----
 consul_profiles:
-  -
-    production:
+    -
+      name: production
       ca_cert_path: /etc/ssl/certs/ca.pem
       client_cert_path: /etc/ssl/certs/client-cert.pem
       client_key_path: /etc/ssl/private/client-key.pem
@@ -11,8 +11,9 @@ consul_profiles:
       scheme: https
       token: 11111111-bbbb-aaaa-cccc-222222222222
       verify: true
-  -
-    dev:
+      preserve_varenv: false
+    -
+      name: dev
       ca_cert_path: /etc/ssl/certs/dev-ca.pem
       client_cert_path: /etc/ssl/certs/dev-client-cert.pem
       client_key_path: /etc/ssl/private/dev-client-key.pem
@@ -22,4 +23,5 @@ consul_profiles:
       scheme: https
       token: 22222222-bbbb-aaaa-cccc-444444444444
       verify: false
+      preserve_varenv: false
 default_profile: production

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-consul>=0.3.3
+python-consul>=1.1.0


### PR DESCRIPTION
- Adds support for consul server profiles
- Use python-consul 1.1.0
- Add support for ACLs.