### PR TITLE
Update compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [2.0.0] 03 Nov 2021
+### Changed
+* Changed underlying consul library from `python-consul` which is no longer maintained to `python-consul2` which is maintained.
+* Certain Python3 libraries return byte strings.  We need to decode them in order to correctly json-ify them.
+
 ## [1.0.0] 05 Feb 2021
 
 * Drop Python 2.7 support

--- a/actions/kv_get.py
+++ b/actions/kv_get.py
@@ -36,9 +36,9 @@ class ConsulKVGetAction(action.ConsulBaseAction):
 
         if from_json and not keys:
             if isinstance(res, dict):
-                res["Value"] = self.from_json(res["Value"])
+                res["Value"] = self.from_json(res["Value"].decode('utf-8'))
             if isinstance(res, list):
                 for item in res:
-                    item["Value"] = self.from_json(item["Value"])
+                    item["Value"] = self.from_json(item["Value"].decode('utf-8'))
 
         return (True, [idx, res])

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: consul
 name: consul
 description: consul
-version: 1.0.0
+version: 2.0.0
 python_versions:
   - "3"
 author: jfryman

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-consul>=1.1.0
+python-consul2>=0.1.5


### PR DESCRIPTION
* Changed underlying consul library from `python-consul` which is no longer maintained to `python-consul2` which is maintained.
* Certain Python3 libraries return byte strings.  We need to decode them in order to correctly json-ify them.